### PR TITLE
Fix/sleep ave quality method

### DIFF
--- a/src/Fitness.js
+++ b/src/Fitness.js
@@ -5,7 +5,7 @@ class Fitness {
 
   getAverage(data, property = null) {
     return data.reduce((total, value) => {
-      property === null ? total += value : total += value[property]
+      property === null ? total += value : (total += parseFloat(value[property]));
       return total;
     }, 0) / data.length;
   }

--- a/src/Sleep.js
+++ b/src/Sleep.js
@@ -43,7 +43,7 @@ class Sleep extends Fitness {
   }
 
   calculateAllUserSleepQuality() {
-    var totalSleepQuality = this.getAverage(this.sleepData, "sleepQuality");
+    var totalSleepQuality = this.getAverage(this.sleepData, "sleepQuality").toFixed(1);
     return totalSleepQuality;
   }
 

--- a/src/dom-display.js
+++ b/src/dom-display.js
@@ -33,7 +33,7 @@ let domDisplay = {
   addSleepInfo(id, sleepInfo, dateString, userStorage, laterDateString) {
     $('#sleepToday').prepend(`<p>You slept</p> <p><span class="number">${sleepInfo.calculateDailySleep(id, dateString)}</span></p> <p>hours today.</p>`);
     $('#sleepQualityToday').prepend(`<p>Your sleep quality was</p> <p><span class="number">${sleepInfo.calculateDailySleepQuality(id, dateString)}</span></p><p>out of 5.</p>`);
-    $('#avUserSleepQuality').prepend(`<p>The average user's sleep quality is</p> <p><span class="number">${Math.round(sleepInfo.calculateAllUserSleepQuality() * 100) / 100}</span></p><p>out of 5.</p>`);
+    $('#avUserSleepQuality').prepend(`<p>The average sleep quality of all users is</p> <p><span class="number">${Math.round(sleepInfo.calculateAllUserSleepQuality()).toFixed(1)}</span></p><p>out of 5.</p>`);
     $('#sleepThisWeek').prepend(domDisplay.makeSleepHTML(id, sleepInfo, userStorage, sleepInfo.calculateWeekSleep(dateString, id, userStorage)));
     $('#sleepEarlierWeek').prepend(domDisplay.makeSleepHTML(id, sleepInfo, userStorage, sleepInfo.calculateWeekSleep(laterDateString, id, userStorage)));
   },

--- a/test/sleep-test.js
+++ b/test/sleep-test.js
@@ -353,7 +353,7 @@ describe('Sleep', function() {
   });
 
   it('should calculate all users sleep quality', function() {
-    expect(sleep.calculateAllUserSleepQuality().toFixed(2)).to.eql("2.98");
+    expect(sleep.calculateAllUserSleepQuality()).to.eql("3.0");
   });
 
   it('should return user names', function() {


### PR DESCRIPTION
## What is the change?
Fix and issue of displaying an average sleep quality of all users as NaN. Now it's a rounded float number. 
getAverage() function in Fitness class was adjusted so it can work with float numbers too. 
calculateAllUserSleepQuality() in Sleep class was adjusted wtih toFixed(1) to return only a float number with one decimal.
#avUserSleepQuality in dom-display.js was rephrased to match the provided information. 
 
## What does it fix? 
Accuracy of displayed data in the browser.

## Is this a fix or a feature?  
Fix

## Where should the reviewer start? 
Fintness.js: line 8
Sleep.js: line 46
dom-display: line 36
sleep-test: line 356

## How should this be tested?
By running npm test should which should show all successfully passed tests. By running npm start the browser should display all random user related information.